### PR TITLE
Log4j needs to be updated urgently

### DIFF
--- a/IntelMissionControl/pom.xml
+++ b/IntelMissionControl/pom.xml
@@ -551,17 +551,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.0</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.13.0</version>
+            <version>2.15.0</version>
         </dependency>
 
         <!-- *******************************************************************


### PR DESCRIPTION
log4j needs to be updated to latest version since there is CVE for log4j versions used.